### PR TITLE
feat: add delete endpoint for picker resource

### DIFF
--- a/src/adapters/repositories/filters_repository.py
+++ b/src/adapters/repositories/filters_repository.py
@@ -35,6 +35,12 @@ class FiltersRepository(FiltersPort):
             created_at=data["created_at"],
         )
 
+    def delete(self, filter_id: int) -> bool:
+        sql = text("DELETE FROM filters WHERE id = :id RETURNING id")
+        result = self.db.execute(sql, {"id": filter_id}).first()
+        self.db.commit()
+        return result is not None
+
     def get_by_picker_id(self, picker_id: int) -> list[Filter]:
         sql = text(
             "SELECT id, picker_id, operation, args, created_at "

--- a/src/adapters/repositories/pickers_repository.py
+++ b/src/adapters/repositories/pickers_repository.py
@@ -38,6 +38,12 @@ class PickersRepository(PickersPort):
             created_at=data["created_at"],
         )
 
+    def delete(self, picker_id: int) -> bool:
+        sql = text("DELETE FROM pickers WHERE id = :id RETURNING id")
+        result = self.db.execute(sql, {"id": picker_id}).first()
+        self.db.commit()
+        return result is not None
+
     def get_by_external_id(self, external_id: UUID) -> Picker | None:
         sql = text(
             "SELECT id, external_id, source_id, feed_id, cronjob, created_at "

--- a/src/domain/ports/filters_port.py
+++ b/src/domain/ports/filters_port.py
@@ -10,5 +10,9 @@ class FiltersPort(ABC):
         pass
 
     @abstractmethod
+    def delete(self, filter_id: int) -> bool:
+        pass
+
+    @abstractmethod
     def get_by_picker_id(self, picker_id: int) -> list[Filter]:
         pass

--- a/src/domain/ports/pickers_port.py
+++ b/src/domain/ports/pickers_port.py
@@ -11,5 +11,9 @@ class PickersPort(ABC):
         pass
 
     @abstractmethod
+    def delete(self, picker_id: int) -> bool:
+        pass
+
+    @abstractmethod
     def get_by_external_id(self, external_id: UUID) -> Picker | None:
         pass

--- a/src/domain/services/filter_service.py
+++ b/src/domain/services/filter_service.py
@@ -9,5 +9,8 @@ class FilterService:
     def create_filter(self, filter_request: FilterRequest) -> Filter:
         return self.filters_port.create(filter_request)
 
+    def delete_filter(self, filter_id: int) -> bool:
+        return self.filters_port.delete(filter_id)
+
     def get_filters_by_picker_id(self, picker_id: int) -> list[Filter]:
         return self.filters_port.get_by_picker_id(picker_id)

--- a/src/domain/services/picker_service.py
+++ b/src/domain/services/picker_service.py
@@ -11,5 +11,8 @@ class PickerService:
     def create_picker(self, picker_request: PickerRequest) -> Picker:
         return self.pickers_port.create(picker_request)
 
+    def delete_picker(self, picker_id: int) -> bool:
+        return self.pickers_port.delete(picker_id)
+
     def get_picker_by_external_id(self, external_id: UUID) -> Picker:
         return self.pickers_port.get_by_external_id(external_id)

--- a/src/main.py
+++ b/src/main.py
@@ -235,6 +235,29 @@ def get_picker(
         filters=filter_items
     )
 
+@app.delete(
+    "/v1/pickers/{picker_external_id}",
+    status_code=status.HTTP_204_NO_CONTENT
+)
+def delete_picker(
+    picker_external_id: UUID,
+    filter_service: FilterService = Depends(get_filter_service), # noqa: B008
+    picker_service: PickerService = Depends(get_picker_service), # noqa: B008
+):
+    picker = picker_service.get_picker_by_external_id(external_id=picker_external_id)
+    if not picker:
+        raise HTTPException(status_code=404, detail="Picker not found")
+
+    # delete filters
+    filters = filter_service.get_filters_by_picker_id(picker_id=picker.id)
+    for filter in filters:
+        filter_service.delete_filter(filter.id)
+
+    # delete picker
+    picker_service.delete_picker(picker_id=picker.id)
+
+    return None
+
 
 @app.post("/v1/job/", status_code=status.HTTP_201_CREATED)
 def add_cronjob(

--- a/tests/unit/domain/services/test_filter_service.py
+++ b/tests/unit/domain/services/test_filter_service.py
@@ -82,3 +82,27 @@ def test_get_filters_by_picker_id_returns_empty(filter_service, filters_port_moc
     # THEN
     filters_port_mock.get_by_picker_id.assert_called_once()
     assert all_filters == filters
+
+
+def test_delete_filter_success(filter_service, filters_port_mock):
+    # GIVEN
+    filters_port_mock.delete.return_value = True
+
+    # WHEN
+    result = filter_service.delete_filter(123)
+
+    # THEN
+    filters_port_mock.delete.assert_called_once_with(123)
+    assert result is True
+
+
+def test_delete_filter_not_found(filter_service, filters_port_mock):
+    # GIVEN
+    filters_port_mock.delete.return_value = False
+
+    # WHEN
+    result = filter_service.delete_filter(999)
+
+    # THEN
+    filters_port_mock.delete.assert_called_once_with(999)
+    assert result is False

--- a/tests/unit/domain/services/test_picker_service.py
+++ b/tests/unit/domain/services/test_picker_service.py
@@ -78,3 +78,27 @@ def test_get_filters_by_picker_id_returns_none(picker_service, pickers_port_mock
     # THEN
     pickers_port_mock.get_by_external_id.assert_called_once()
     assert picker_response is None
+
+
+def test_delete_picker_success(picker_service, pickers_port_mock):
+    # GIVEN
+    pickers_port_mock.delete.return_value = True
+
+    # WHEN
+    result = picker_service.delete_picker(123)
+
+    # THEN
+    pickers_port_mock.delete.assert_called_once_with(123)
+    assert result is True
+
+
+def test_delete_filter_not_found(picker_service, pickers_port_mock):
+    # GIVEN
+    pickers_port_mock.delete.return_value = False
+
+    # WHEN
+    result = picker_service.delete_picker(999)
+
+    # THEN
+    pickers_port_mock.delete.assert_called_once_with(999)
+    assert result is False


### PR DESCRIPTION
# Description
This Pull Request adds the delete endpoint for the picker resource.

`DEL /api/pickers/{external_id}`

**Integration test:**
<img width="692" height="272" alt="image" src="https://github.com/user-attachments/assets/28bc010f-9ba2-44d8-87ed-c7a9e5058db7" />
