### PR TITLE
feat: add get feed endpoints

### DIFF
--- a/infrastructure/db/alembic/versions/dd3ce30a0a72_create_first_db_version.py
+++ b/infrastructure/db/alembic/versions/dd3ce30a0a72_create_first_db_version.py
@@ -36,6 +36,16 @@ def upgrade():
             created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP
         );
         
+        CREATE TABLE feed_items (
+            id SERIAL PRIMARY KEY,
+            title TEXT,
+            description TEXT,
+            link TEXT,
+            feed_id INT NOT NULL REFERENCES feeds(id),
+            external_id UUID NOT NULL DEFAULT gen_random_uuid(),
+            created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP
+        );
+        
         CREATE TABLE pickers (
             id SERIAL PRIMARY KEY,
             external_id UUID NOT NULL DEFAULT gen_random_uuid(),
@@ -73,6 +83,7 @@ def downgrade():
         DROP TABLE pickers;
         DROP TABLE sources;
         DROP TABLE feeds;
+        DROP TABLE feed_items;
         DROP TABLE jobs;
         DROP TYPE operation;
         """

--- a/poetry.lock
+++ b/poetry.lock
@@ -244,6 +244,21 @@ standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.8)", "htt
 standard-no-fastapi-cloud-cli = ["email-validator (>=2.0.0)", "fastapi-cli[standard-no-fastapi-cloud-cli] (>=0.0.8)", "httpx (>=0.23.0)", "jinja2 (>=3.1.5)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
 
 [[package]]
+name = "feedgenerator"
+version = "2.2.1"
+description = "Standalone version of django.utils.feedgenerator"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "feedgenerator-2.2.1-py3-none-any.whl", hash = "sha256:0d8bb321e49dd43c916b659e137c1eab1b1c053dd4535a03ef8d47e5f3358ba5"},
+    {file = "feedgenerator-2.2.1.tar.gz", hash = "sha256:0eaa955f1f0bcb5b87ac195af740f06ff9fff4a40ed30b8a7c6bbebb264d4dd1"},
+]
+
+[package.dependencies]
+tzdata = {version = "*", markers = "sys_platform == \"win32\""}
+
+[[package]]
 name = "greenlet"
 version = "3.2.4"
 description = "Lightweight in-process concurrent programming"
@@ -1065,4 +1080,4 @@ standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "87e444faee39b0c658032744781fb6fb236aa7ba02d1aff221dfc8a02ccb7156"
+content-hash = "2c6c20387a481da64b013cfb30cb004ee8ec2c0184385aacf954f27780978030"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "psycopg2-binary (>=2.9.10,<3.0.0)",
     "psycopg (>=3.2.9,<4.0.0)",
     "apscheduler (>=3.11.0,<4.0.0)",
+    "feedgenerator (>=2.2.1,<3.0.0)",
 ]
 
 [tool.poetry]

--- a/src/adapters/entrypoints/v1/models/feeds.py
+++ b/src/adapters/entrypoints/v1/models/feeds.py
@@ -2,7 +2,8 @@ from datetime import datetime
 from uuid import UUID
 
 from pydantic import BaseModel
-from src.domain.models.feed import Feed, FeedRequest
+from src.adapters.entrypoints.v1.models.picker import FullFeedPickerResponse
+from src.domain.models.feed import Feed, FeedItem, FeedRequest
 
 
 class CreateFeedRequest(BaseModel):
@@ -23,6 +24,22 @@ class ExternalFeeds(BaseModel):
 
 class ListFeedsResponse(BaseModel):
     feeds: list[ExternalFeeds]
+
+
+class ExternalFeedItem(BaseModel):
+    external_id: UUID
+    link: str
+    title: str
+    created_at: datetime
+
+
+class FullCompleteFeed(BaseModel):
+    name: str
+    external_id: UUID
+    created_at: datetime
+    pickers: list[FullFeedPickerResponse]
+    feed_items: list[ExternalFeedItem]
+
 
 
 def map_create_feed_request_to_feed_request(
@@ -55,4 +72,15 @@ def map_feeds_list_to_list_feeds_response(
             )
             for feed in feeds_list
         ]
+    )
+
+
+def map_feed_item_to_external_feed_item(
+    feed_item: FeedItem
+):
+    return ExternalFeedItem(
+        external_id=feed_item.external_id,
+        link=feed_item.link,
+        title=feed_item.title,
+        created_at=feed_item.created_at
     )

--- a/src/adapters/entrypoints/v1/models/picker.py
+++ b/src/adapters/entrypoints/v1/models/picker.py
@@ -27,3 +27,11 @@ class FullPickerResponse(BaseModel):
     feed_external_id: UUID
     external_id: UUID
     created_at: datetime
+
+
+class FullFeedPickerResponse(BaseModel):
+    cronjob: str
+    source_url: str
+    filters: list[FilterItem]
+    external_id: UUID
+    created_at: datetime

--- a/src/adapters/repositories/feeds_repository.py
+++ b/src/adapters/repositories/feeds_repository.py
@@ -2,7 +2,7 @@ from uuid import UUID
 
 from sqlalchemy import text
 from sqlalchemy.orm import Session
-from src.domain.models.feed import Feed, FeedRequest
+from src.domain.models.feed import Feed, FeedItem, FeedRequest
 from src.domain.ports.feeds_port import FeedsPort
 
 
@@ -61,3 +61,15 @@ class FeedsRepository(FeedsPort):
         if result:
             return Feed(**result)
         return None
+
+    def get_feed_items(self, feed_id: int) -> list[FeedItem]:
+        sql = text(
+            "SELECT id, feed_id, external_id, link, title, description, created_at "
+            "FROM feed_items WHERE feed_id = :feed_id;"
+        )
+        result = self.db.execute(
+            sql,
+            {"feed_id": feed_id}
+        ).mappings()
+
+        return [FeedItem(**feed_item) for feed_item in result]

--- a/src/adapters/repositories/pickers_repository.py
+++ b/src/adapters/repositories/pickers_repository.py
@@ -54,3 +54,15 @@ class PickersRepository(PickersPort):
         if result:
             return Picker(**result)
         return None
+
+    def get_pickers_by_feed_id(
+        self,
+        feed_id: int
+    ) -> list[Picker]:
+        sql = text(
+            "SELECT id, external_id, source_id, feed_id, cronjob, created_at "
+            "FROM pickers WHERE feed_id = :feed_id;"
+        )
+        result = self.db.execute(sql, {"feed_id": feed_id}).mappings()
+
+        return [Picker(**picker) for picker in result]

--- a/src/domain/models/feed.py
+++ b/src/domain/models/feed.py
@@ -13,3 +13,13 @@ class Feed(BaseModel):
     external_id: UUID
     name: str | None
     created_at: datetime
+
+
+class FeedItem(BaseModel):
+    id: int
+    external_id: UUID
+    link: str
+    title: str
+    description: str
+    created_at: datetime
+    feed_id: int

--- a/src/domain/ports/feeds_port.py
+++ b/src/domain/ports/feeds_port.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from uuid import UUID
 
-from src.domain.models.feed import Feed, FeedRequest
+from src.domain.models.feed import Feed, FeedItem, FeedRequest
 
 
 class FeedsPort(ABC):
@@ -20,4 +20,8 @@ class FeedsPort(ABC):
 
     @abstractmethod
     def get_by_id(self, id: int) -> Feed | None:
+        pass
+
+    @abstractmethod
+    def get_feed_items(self, feed_id: int) -> list[FeedItem]:
         pass

--- a/src/domain/ports/pickers_port.py
+++ b/src/domain/ports/pickers_port.py
@@ -17,3 +17,7 @@ class PickersPort(ABC):
     @abstractmethod
     def get_by_external_id(self, external_id: UUID) -> Picker | None:
         pass
+
+    @abstractmethod
+    def get_pickers_by_feed_id(self, feed_id: int) -> list[Picker]:
+        pass

--- a/src/domain/services/feed_service.py
+++ b/src/domain/services/feed_service.py
@@ -1,4 +1,7 @@
-from src.domain.models.feed import Feed, FeedRequest
+from uuid import UUID
+
+from feedgenerator import Rss201rev2Feed
+from src.domain.models.feed import Feed, FeedItem, FeedRequest
 from src.domain.ports.feeds_port import FeedsPort
 
 
@@ -12,8 +15,30 @@ class FeedService:
     def get_all_feeds(self) -> list[Feed]:
         return self.feeds_port.get_all()
 
-    def get_feed_by_external_id(self, external_id) -> Feed | None:
+    def get_feed_by_external_id(self, external_id: UUID) -> Feed | None:
         return self.feeds_port.get_by_external_id(external_id)
 
     def get_feed_by_id(self, id: int) -> Feed | None:
         return self.feeds_port.get_by_id(id)
+
+    def get_feed_items(self, feed_id: int) -> list[FeedItem]:
+        return self.feeds_port.get_feed_items(feed_id)
+
+    def get_rss(self, feed_external_id: UUID) -> str:
+        feed = self.feeds_port.get_by_external_id(feed_external_id)
+        feed_items = self.feeds_port.get_feed_items(feed.id)
+        feed_object = Rss201rev2Feed(
+            title=feed.name,
+            link="http://127.0.0.1:8080/" + str(feed.external_id),
+            description=feed.name,
+            language="en",
+        )
+        for feed_item in feed_items:
+            feed_object.add_item(
+                title=feed_item.title,
+                link=feed_item.link,
+                description=feed_item.description,
+                pubdate=feed_item.created_at
+            )
+
+        return feed_object.writeString("utf-8")

--- a/src/domain/services/picker_service.py
+++ b/src/domain/services/picker_service.py
@@ -16,3 +16,6 @@ class PickerService:
 
     def get_picker_by_external_id(self, external_id: UUID) -> Picker:
         return self.pickers_port.get_by_external_id(external_id)
+
+    def get_pickers_by_feed_id(self, feed_id: int) -> list[Picker]:
+        return self.pickers_port.get_pickers_by_feed_id(feed_id)

--- a/tests/unit/domain/services/test_feed_service.py
+++ b/tests/unit/domain/services/test_feed_service.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
-from src.domain.models.feed import Feed, FeedRequest
+from src.domain.models.feed import Feed, FeedItem, FeedRequest
 from src.domain.services.feed_service import FeedService
 
 
@@ -59,3 +59,81 @@ def test_get_all_feeds(feed_service, feeds_port_mock):
     # THEN
     feeds_port_mock.get_all.assert_called_once()
     assert all_feeds == feeds
+
+
+def test_get_feed_items_delegates_to_port(feed_service, feeds_port_mock):
+    # GIVEN
+    expected_items = [MagicMock(spec=FeedItem), MagicMock(spec=FeedItem)]
+    feeds_port_mock.get_feed_items.return_value = expected_items
+
+    # WHEN
+    result = feed_service.get_feed_items(feed_id=42)
+
+    # THEN
+    feeds_port_mock.get_feed_items.assert_called_once_with(42)
+    assert result == expected_items
+
+
+def test_get_rss_builds_rss_feed(feed_service, feeds_port_mock):
+    # GIVEN
+    feed = Feed(
+        id=1,
+        name="Example Feed",
+        external_id=uuid4(),
+        created_at=datetime(2025, 1, 1, 12, 0, 0),
+    )
+    items = [
+        FeedItem(
+            id=10,
+            feed_id=feed.id,
+            external_id=uuid4(),
+            link="https://example.com/1",
+            title="First item",
+            description="Desc 1",
+            created_at=datetime(2025, 1, 2, 12, 0, 0),
+        ),
+        FeedItem(
+            id=11,
+            feed_id=feed.id,
+            external_id=uuid4(),
+            link="https://example.com/2",
+            title="Second item",
+            description="Desc 2",
+            created_at=datetime(2025, 1, 3, 12, 0, 0),
+        ),
+    ]
+    feeds_port_mock.get_by_external_id.return_value = feed
+    feeds_port_mock.get_feed_items.return_value = items
+
+    # WHEN
+    rss_xml = feed_service.get_rss(feed.external_id)
+
+    # THEN
+    assert "<rss" in rss_xml
+    assert "<title>Example Feed</title>" in rss_xml
+    assert "https://example.com/1" in rss_xml
+    assert "First item" in rss_xml
+    assert "Second item" in rss_xml
+    assert "<description>Desc 2</description>" in rss_xml
+
+    feeds_port_mock.get_by_external_id.assert_called_once_with(feed.external_id)
+    feeds_port_mock.get_feed_items.assert_called_once_with(feed.id)
+
+
+def test_get_feed_by_external_id_delegates(feed_service, feeds_port_mock):
+    # GIVEN
+    external_id = uuid4()
+    feed = Feed(
+        id=99,
+        name="Delegated Feed",
+        external_id=external_id,
+        created_at=datetime(2025, 2, 1, 12, 0, 0),
+    )
+    feeds_port_mock.get_by_external_id.return_value = feed
+
+    # WHEN
+    result = feed_service.get_feed_by_external_id(external_id)
+
+    # THEN
+    feeds_port_mock.get_by_external_id.assert_called_once_with(external_id)
+    assert result == feed

--- a/tests/unit/domain/services/test_picker_service.py
+++ b/tests/unit/domain/services/test_picker_service.py
@@ -102,3 +102,48 @@ def test_delete_filter_not_found(picker_service, pickers_port_mock):
     # THEN
     pickers_port_mock.delete.assert_called_once_with(999)
     assert result is False
+
+
+def test_get_pickers_by_feed_id_returns_list(picker_service, pickers_port_mock):
+    # GIVEN
+    feed_id = 42
+    pickers = [
+        Picker(
+            id=1,
+            external_id=uuid4(),
+            source_id=101,
+            feed_id=feed_id,
+            cronjob="0 * * * *",
+            created_at=datetime(2025, 1, 1, 12, 0, 0),
+        ),
+        Picker(
+            id=2,
+            external_id=uuid4(),
+            source_id=102,
+            feed_id=feed_id,
+            cronjob="30 * * * *",
+            created_at=datetime(2025, 1, 1, 13, 0, 0),
+        ),
+    ]
+    pickers_port_mock.get_pickers_by_feed_id.return_value = pickers
+
+    # WHEN
+    result = picker_service.get_pickers_by_feed_id(feed_id)
+
+    # THEN
+    pickers_port_mock.get_pickers_by_feed_id.assert_called_once_with(feed_id)
+    assert result == pickers
+    assert all(isinstance(p, Picker) for p in result)
+    assert all(p.feed_id == feed_id for p in result)
+
+
+def test_get_pickers_by_feed_id_returns_empty(picker_service, pickers_port_mock):
+    # GIVEN
+    pickers_port_mock.get_pickers_by_feed_id.return_value = []
+
+    # WHEN
+    result = picker_service.get_pickers_by_feed_id(123)
+
+    # THEN
+    pickers_port_mock.get_pickers_by_feed_id.assert_called_once_with(123)
+    assert result == []


### PR DESCRIPTION
# Description
This Pull Request adds 2 new endpoints:
- `GET /api/feeds/<external_id>`
- `GET /api/feeds/<external_id>.xml`

**New table**

<img width="200" height="754" alt="image" src="https://github.com/user-attachments/assets/01c00dce-df1e-4c42-ad69-b74084a771e4" />



**Responses**

```
GET /api/feeds/<external_id>

{
  name,
  external_id
  created_at
  pickers: [
    {
      external_id,
      filters: [
        {
          operation,
          args,
        },
        {
          operation,
          args,
        }
      ],
      cronjob
      source_url,
    },
    {
      external_id,
      filters: [
        {
          operation,
          args,
        },
        {
          operation,
          args,
        }
      ],
      cronjob
      source_url,
    },
  ],
  items: [
    {
      external_id,
      link,
      title,
      created_at
    },
    {
      external_id,
      link,
      title,
      created_at
    }
  ]
}
```
