### PR TITLE
feat: add contain operations

### DIFF
--- a/infrastructure/db/alembic/versions/dd3ce30a0a72_create_first_db_version.py
+++ b/infrastructure/db/alembic/versions/dd3ce30a0a72_create_first_db_version.py
@@ -55,8 +55,14 @@ def upgrade():
             created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP
         );
         
-        CREATE TYPE operation AS ENUM ('identity');
-        
+        CREATE TYPE operation AS ENUM (
+            'identity', 
+            'title_contains', 
+            'description_contains',
+            'title_does_not_contain',
+            'description_does_not_contain'
+        );
+
         CREATE TABLE filters (
             id SERIAL PRIMARY KEY,
             picker_id INT NOT NULL REFERENCES pickers(id),

--- a/src/domain/handlers/operations.py
+++ b/src/domain/handlers/operations.py
@@ -1,2 +1,42 @@
 def identity(to_add: bool):
     return to_add
+
+def title_contains(
+    to_add: bool,
+    title: str,
+    expression: str,
+    count: int
+):
+    if title.count(expression) < count:
+        return False
+    return to_add
+
+def description_contains(
+    to_add: bool,
+    description: str,
+    expression: str,
+    count: int
+):
+    if description.count(expression) < count:
+        return False
+    return to_add
+
+def title_does_not_contain(
+    to_add: bool,
+    title: str,
+    expression: str,
+    count: int
+):
+    if title.count(expression) >= count:
+        return False
+    return to_add
+
+def description_does_not_contain(
+    to_add: bool,
+    description: str,
+    expression: str,
+    count: int
+):
+    if description.count(expression) >= count:
+        return False
+    return to_add

--- a/src/domain/models/filter.py
+++ b/src/domain/models/filter.py
@@ -6,6 +6,10 @@ from pydantic import BaseModel
 
 class Operation(str, Enum):
     identity = "identity"
+    title_contains = "title_contains"
+    description_contains = "description_contains"
+    title_does_not_contain = "title_does_not_contain"
+    description_does_not_contain = "description_does_not_contain"
 
 
 class Filter(BaseModel):

--- a/src/domain/services/job_service.py
+++ b/src/domain/services/job_service.py
@@ -1,5 +1,13 @@
+import ast
+
 import feedparser
-from src.domain.handlers.operations import identity
+from src.domain.handlers.operations import (
+    description_contains,
+    description_does_not_contain,
+    identity,
+    title_contains,
+    title_does_not_contain,
+)
 from src.domain.models.feed import FeedItemRequest
 from src.domain.models.filter import Operation
 from src.domain.models.job import Job
@@ -61,10 +69,47 @@ class JobService:
         for entry in new_entries:
             to_add = True
             for filter in filters:
+                args = ast.literal_eval(filter.args)
 
                 # identity operation
                 if filter.operation is Operation.identity:
                     to_add = identity(to_add)
+
+                # title_contains operation
+                if filter.operation is Operation.title_contains:
+                    to_add = title_contains(
+                        to_add,
+                        entry.title,
+                        args[0],
+                        int(args[1])
+                    )
+
+                # description_contains operation
+                if filter.operation is Operation.description_contains:
+                    to_add = description_contains(
+                        to_add,
+                        entry.description,
+                        args[0],
+                        int(args[1])
+                    )
+
+                # title_does_not_contain operation
+                if filter.operation is Operation.title_does_not_contain:
+                    to_add = title_does_not_contain(
+                        to_add,
+                        entry.description,
+                        args[0],
+                        int(args[1])
+                    )
+
+                # description_does_not_contain operation
+                if filter.operation is Operation.description_does_not_contain:
+                    to_add = description_does_not_contain(
+                        to_add,
+                        entry.description,
+                        args[0],
+                        int(args[1])
+                    )
 
             if to_add:
                 feed_item_request = FeedItemRequest(

--- a/tests/unit/domain/handlers/test_operations.py
+++ b/tests/unit/domain/handlers/test_operations.py
@@ -1,5 +1,11 @@
 import pytest
-from src.domain.handlers.operations import identity
+from src.domain.handlers.operations import (
+    description_contains,
+    description_does_not_contain,
+    identity,
+    title_contains,
+    title_does_not_contain,
+)
 
 
 @pytest.mark.parametrize("input_value", [True, False])
@@ -9,3 +15,71 @@ def test_identity_returns_same_value(input_value):
 
     # THEN
     assert result == input_value
+
+
+@pytest.mark.parametrize(
+    ("title", "expression", "count", "expected"),
+    [
+        ("this title has exoplanet", "exoplanet", 1, True),
+        ("this title has exoplanet exoplanet", "exoplanet", 2, True),
+        ("this title has no match", "exoplanet", 1, False),
+        ("this title has one exoplanet", "exoplanet", 2, False),
+    ],
+)
+def test_title_contains(title, expression, count, expected):
+    # WHEN
+    result = title_contains(True, title, expression, count)
+
+    # THEN
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("description", "expression", "count", "expected"),
+    [
+        ("description with keyword", "keyword", 1, True),
+        ("keyword keyword description", "keyword", 2, True),
+        ("no match here", "keyword", 1, False),
+        ("only one keyword", "keyword", 2, False),
+    ],
+)
+def test_description_contains(description, expression, count, expected):
+    # WHEN
+    result = description_contains(True, description, expression, count)
+
+    # THEN
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("title", "expression", "count", "expected"),
+    [
+        ("this title has keyword", "keyword", 1, False),
+        ("keyword keyword title", "keyword", 2, False),
+        ("title without it", "keyword", 1, True),
+        ("only one keyword", "keyword", 2, True),
+    ],
+)
+def test_title_does_not_contain(title, expression, count, expected):
+    # WHEN
+    result = title_does_not_contain(True, title, expression, count)
+
+    # THEN
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("description", "expression", "count", "expected"),
+    [
+        ("this description has keyword", "keyword", 1, False),
+        ("keyword keyword description", "keyword", 2, False),
+        ("no match here", "keyword", 1, True),
+        ("only one keyword", "keyword", 2, True),
+    ],
+)
+def test_description_does_not_contain(description, expression, count, expected):
+    # WHEN
+    result = description_does_not_contain(True, description, expression, count)
+
+    # THEN
+    assert result == expected

--- a/tests/unit/domain/services/test_job_service.py
+++ b/tests/unit/domain/services/test_job_service.py
@@ -90,8 +90,10 @@ def test_process_adds_new_entry(mock_parse, job_service, mock_services):
         created_at=datetime(2025, 1, 1, 13, 0, 0)
     )
     mock_services["picker_service"].get_picker_by_id.return_value = picker
+    filter_mock = MagicMock(operation=Operation.identity)
+    filter_mock.args = "[]"
     mock_services["filter_service"].get_filters_by_picker_id.return_value = [
-        MagicMock(operation=Operation.identity)
+        filter_mock
     ]
     mock_services["feed_service"].get_feed_items.return_value = []
     mock_services["source_service"].get_source_by_id.return_value = MagicMock(
@@ -154,9 +156,9 @@ def test_process_with_identity_filter_false(mock_parse, job_service, mock_servic
     )
     mock_services["picker_service"].get_picker_by_id.return_value = picker
     # Returning an "identity" filter ensures identity() gets called
-    mock_services["filter_service"].get_filters_by_picker_id.return_value = [
-        MagicMock(operation=Operation.identity)
-    ]
+    filter_mock = MagicMock(operation=Operation.identity)
+    filter_mock.args = "[]"
+    mock_services["filter_service"].get_filters_by_picker_id.return_value = [filter_mock]
     mock_services["feed_service"].get_feed_items.return_value = []
     mock_services["source_service"].get_source_by_id.return_value = MagicMock(
         url="http://example.com/feed"
@@ -170,3 +172,111 @@ def test_process_with_identity_filter_false(mock_parse, job_service, mock_servic
 
     # Since identity just returns True unchanged, item is created
     mock_services["feed_service"].create_feed_item.assert_called_once()
+
+@patch("src.domain.services.job_service.feedparser.parse")
+def test_process_with_title_contains_filter(mock_parse, job_service, mock_services):
+    picker = Picker(
+        id=1,
+        cronjob="*/5 * * * *",
+        source_id=10,
+        feed_id=20,
+        external_id=uuid4(),
+        created_at=datetime(2025, 1, 1, 13, 0, 0),
+    )
+    mock_services["picker_service"].get_picker_by_id.return_value = picker
+
+    # Filter requires "Article" at least once in the title
+    filter_mock = MagicMock(
+        operation=Operation.title_contains,
+        args="['Article', 1]"
+    )
+    mock_services["filter_service"].get_filters_by_picker_id.return_value = [filter_mock]
+    mock_services["feed_service"].get_feed_items.return_value = []
+    mock_services["source_service"].get_source_by_id.return_value = MagicMock(
+        url="http://example.com/feed"
+    )
+
+    mock_parse.return_value.entries = [
+        MagicMock(link="http://example.com/article", title="Article 123", description="Some text")
+    ]
+
+    job_service.process(picker_id=1)
+
+    mock_services["feed_service"].create_feed_item.assert_called_once()
+
+
+@patch("src.domain.services.job_service.feedparser.parse")
+def test_process_with_description_contains_filter_fails(mock_parse, job_service, mock_services):
+    picker = Picker(
+        id=1, cronjob="*", source_id=10, feed_id=20, external_id=uuid4(), created_at=datetime.now()
+    )
+    mock_services["picker_service"].get_picker_by_id.return_value = picker
+
+    # Requires "banana" to appear in description at least 2 times
+    filter_mock = MagicMock(
+        operation=Operation.description_contains,
+        args="['banana', 2]"
+    )
+    mock_services["filter_service"].get_filters_by_picker_id.return_value = [filter_mock]
+    mock_services["feed_service"].get_feed_items.return_value = []
+    mock_services["source_service"].get_source_by_id.return_value = MagicMock(url="http://feed")
+
+    mock_parse.return_value.entries = [
+        MagicMock(link="http://item", title="Any", description="banana only once")
+    ]
+
+    job_service.process(picker_id=1)
+
+    mock_services["feed_service"].create_feed_item.assert_not_called()
+
+
+@patch("src.domain.services.job_service.ast.literal_eval", return_value=["spam", 1])
+@patch("src.domain.services.job_service.feedparser.parse")
+def test_process_with_title_does_not_contain_filter(mock_parse, job_service, mock_services):
+    picker = Picker(
+        id=1, cronjob="*", source_id=10, feed_id=20, external_id=uuid4(), created_at=datetime.now()
+    )
+    mock_services["picker_service"].get_picker_by_id.return_value = picker
+
+    # Exclude items whose description contains "spam"
+    filter_mock = MagicMock(operation=Operation.title_does_not_contain)
+    filter_mock.args = "['spam', 1]"
+    mock_services["filter_service"].get_filters_by_picker_id.return_value = [filter_mock]
+    mock_services["feed_service"].get_feed_items.return_value = []
+    mock_services["source_service"].get_source_by_id.return_value = MagicMock(url="http://feed")
+
+    mock_parse.return_value.entries = [
+        MagicMock(link="http://item2", title="spam stuff", description="oops"),
+    ]
+    job_service.process(picker_id=1)
+
+    assert mock_services["feed_service"].create_feed_item.call_count == 0
+
+
+@patch("src.domain.services.job_service.feedparser.parse")
+def test_process_with_description_does_not_contain_filter(mock_parse, job_service, mock_services):
+    picker = Picker(
+        id=1, cronjob="*", source_id=10, feed_id=20, external_id=uuid4(), created_at=datetime.now()
+    )
+    mock_services["picker_service"].get_picker_by_id.return_value = picker
+
+    # Exclude items whose description contains "error"
+    filter_mock = MagicMock(
+        operation=Operation.description_does_not_contain,
+        args="['error', 1]"
+    )
+    mock_services["filter_service"].get_filters_by_picker_id.return_value = [filter_mock]
+    mock_services["feed_service"].get_feed_items.return_value = []
+    mock_services["source_service"].get_source_by_id.return_value = MagicMock(url="http://feed")
+
+    mock_parse.return_value.entries = [
+        MagicMock(link="http://ok", title="Good", description="All fine"),
+        MagicMock(link="http://bad", title="Oops", description="error inside"),
+    ]
+
+    job_service.process(picker_id=1)
+
+    # Only the first entry is added
+    assert mock_services["feed_service"].create_feed_item.call_count == 1
+    feed_item = mock_services["feed_service"].create_feed_item.call_args[0][0]
+    assert feed_item.link == "http://ok"


### PR DESCRIPTION
# Description
This Pull Request adds 4 new operations:
- `title_contains`
- `description_contains`
- `title_does_not_contain`
- `description_does_not_contain`

**Database**
```
CREATE TYPE operation AS ENUM (
    'identity', 
    'title_contains', 
    'description_contains',
    'title_does_not_contain',
    'description_does_not_contain'
);
```