### PR TITLE
fix: allow None value for source name

### DIFF
--- a/src/adapters/entrypoints/v1/models/source.py
+++ b/src/adapters/entrypoints/v1/models/source.py
@@ -7,7 +7,7 @@ from src.domain.models.source import Source
 class SourceItem(BaseModel):
     external_id: UUID
     url: str
-    name: str
+    name: str | None
 
 
 class GetAllSourcesResponse(BaseModel):


### PR DESCRIPTION
# Description
This Pull Request fixes the 500 response for `/sources` when source name is None.