### PR TITLE
fix: handle None values in feeds and pickers

### DIFF
--- a/src/adapters/entrypoints/v1/routes.py
+++ b/src/adapters/entrypoints/v1/routes.py
@@ -184,11 +184,13 @@ def get_feed_rss(
     The response content type is `application/rss+xml`.
     """
     feeds_rss = feed_service.get_rss(external_id)
-    return Response(
-        content=feeds_rss,
-        media_type="application/rss+xml",
-        headers={"Content-Disposition": f'inline; filename="{external_id}.xml"'}
-    )
+    if feeds_rss:
+        return Response(
+            content=feeds_rss,
+            media_type="application/rss+xml",
+            headers={"Content-Disposition": f'inline; filename="{external_id}.xml"'}
+        )
+    raise HTTPException(status_code=404, detail="Feed not found")
 
 
 @router.get(
@@ -291,6 +293,8 @@ def add_picker(
         feed = feed_service.get_feed_by_external_id(
             create_full_picker_request.feed_external_id
         )
+        if not feed:
+            raise HTTPException(status_code=400, detail="Feed not found")
     else:
         feed = feed_service.create_feed(
             FeedRequest(
@@ -303,9 +307,12 @@ def add_picker(
         create_full_picker_request.source_url
     )
     if not source:
+        url = create_full_picker_request.source_url
+        source_name = url.split('//')[1].split('/')[0]
         source = source_service.create_source(
             SourceRequest(
-                url=create_full_picker_request.source_url
+                url=create_full_picker_request.source_url,
+                name=source_name
             )
         )
 

--- a/src/domain/services/feed_service.py
+++ b/src/domain/services/feed_service.py
@@ -27,8 +27,10 @@ class FeedService:
     def create_feed_item(self, feed_item_request: FeedItemRequest):
         return self.feeds_port.create_feed_item(feed_item_request)
 
-    def get_rss(self, feed_external_id: UUID) -> str:
+    def get_rss(self, feed_external_id: UUID) -> str | None:
         feed = self.feeds_port.get_feed_by_external_id(feed_external_id)
+        if not feed:
+            return None
         feed_items = self.feeds_port.get_feed_items_by_feed_id(feed.id)
         feed_object = Rss201rev2Feed(
             title=feed.name,


### PR DESCRIPTION
# Description
This PR handles None values in the feeds.xml and pickers routes.
It also fills the source name by default.