### PR TITLE
feat: add get, update and delete endpoints for source

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,7 @@ workflow that is triggered by pushing new tags into the `main` branch.
 Do not forget to change the new version tag in the documentation before
 merging code into the `main` branch and creating the version tag:
 - README.md
+- main.py
 
 Thus, the steps that create a new release are the following:
 

--- a/src/adapters/entrypoints/v1/models/source.py
+++ b/src/adapters/entrypoints/v1/models/source.py
@@ -14,12 +14,12 @@ class GetAllSourcesResponse(BaseModel):
     sources: list[SourceItem] | None
 
 
-class CreateSourceRequest(BaseModel):
+class ExternalSourceRequest(BaseModel):
     url: str
     name: str
 
 
-class CreateSourceResponse(BaseModel):
+class SourceResponse(BaseModel):
     external_id: UUID
     url: str
     name: str
@@ -40,8 +40,8 @@ def map_source_list_to_get_all_sources_response(
 
 def map_source_to_create_source_response(
     source: Source
-) -> CreateSourceResponse:
-    return CreateSourceResponse(
+) -> SourceResponse:
+    return SourceResponse(
         external_id=source.external_id,
         url=source.url,
         name=source.name

--- a/src/adapters/repositories/pickers_repository.py
+++ b/src/adapters/repositories/pickers_repository.py
@@ -86,3 +86,12 @@ class PickersRepository(PickersPort):
         result = self.db.execute(sql).mappings()
 
         return [Picker(**picker) for picker in result]
+
+    def get_picker_by_source_id(self, source_id: int) -> list[Picker]:
+        sql = text(
+            "SELECT id, external_id, source_id, feed_id, cronjob, created_at "
+            "FROM pickers WHERE source_id = :source_id;"
+        )
+        result = self.db.execute(sql, {"source_id": source_id}).mappings()
+
+        return [Picker(**picker) for picker in result]

--- a/src/adapters/repositories/sources_repository.py
+++ b/src/adapters/repositories/sources_repository.py
@@ -35,6 +35,37 @@ class SourcesRepository(SourcePort):
             created_at=result["created_at"],
         )
 
+    def update_source(self, source_id: int, source_request: SourceRequest) -> Source:
+        sql = text(
+            "UPDATE sources "
+            "SET url = :url, name = :name "
+            "WHERE id = :id "
+            "RETURNING id, external_id, url, name, created_at"
+        )
+        result = self.db.execute(
+            sql,
+            {
+                "id": source_id,
+                "url": source_request.url,
+                "name": source_request.name
+            }
+        ).mappings().first()
+        self.db.commit()
+
+        return Source(
+            id=result["id"],
+            external_id=result["external_id"],
+            url=result["url"],
+            name=result["name"],
+            created_at=result["created_at"],
+        )
+
+    def delete_source(self, source_id: int) -> bool:
+        sql = text("DELETE FROM sources WHERE id = :id RETURNING id")
+        result = self.db.execute(sql, {"id": source_id}).first()
+        self.db.commit()
+        return result is not None
+
     def get_all_sources(self) -> list[Source]:
         sql = text("SELECT id, external_id, url, name, created_at FROM sources")
         result = self.db.execute(sql)

--- a/src/domain/ports/pickers_port.py
+++ b/src/domain/ports/pickers_port.py
@@ -29,3 +29,7 @@ class PickersPort(ABC):
     @abstractmethod
     def get_pickers_by_feed_id(self, feed_id: int) -> list[Picker]:
         pass
+
+    @abstractmethod
+    def get_picker_by_source_id(self, source_id: int) -> list[Picker]:
+        pass

--- a/src/domain/ports/sources_port.py
+++ b/src/domain/ports/sources_port.py
@@ -11,6 +11,18 @@ class SourcePort(ABC):
         pass
 
     @abstractmethod
+    def update_source(
+        self,
+        source_id: int,
+        source_request: SourceRequest
+    ) -> Source:
+        pass
+
+    @abstractmethod
+    def delete_source(self, source_id: int) -> bool:
+        pass
+
+    @abstractmethod
     def get_all_sources(self) -> list[Source]:
         pass
 

--- a/src/domain/services/picker_service.py
+++ b/src/domain/services/picker_service.py
@@ -25,3 +25,6 @@ class PickerService:
 
     def get_all_pickers(self) -> list[Picker]:
         return self.pickers_port.get_all_pickers()
+
+    def get_pickers_by_source_id(self, source_id: int) -> list[Picker]:
+        return self.pickers_port.get_picker_by_source_id(source_id)

--- a/src/domain/services/source_service.py
+++ b/src/domain/services/source_service.py
@@ -11,6 +11,19 @@ class SourceService:
     def create_source(self, source_request: SourceRequest) -> Source:
         return self.source_port.create_source(source_request)
 
+    def update_source(
+        self,
+        source_external_id,
+        source_request: SourceRequest
+    ) -> Source | None:
+        source = self.get_source_by_external_id(source_external_id)
+        if source is None:
+            return None
+        return self.source_port.update_source(source.id, source_request)
+
+    def delete_source(self, source_id: int) -> bool:
+        return self.source_port.delete_source(source_id)
+
     def get_all_sources(self) -> list[Source]:
         return self.source_port.get_all_sources()
 

--- a/src/main.py
+++ b/src/main.py
@@ -29,7 +29,7 @@ app = FastAPI(
         "feed generator that fetches content from multiple RSS sources, applies user-defined "
         "filters to remove noise, and publishes a new, clean feed tailored to specific interests."
     ),
-    version="0.1.0",
+    version="0.1.1",
     docs_url="/docs",
     redoc_url="/redoc",
     openapi_url="/openapi.json",

--- a/tests/unit/domain/services/test_source_service.py
+++ b/tests/unit/domain/services/test_source_service.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 from uuid import uuid4
 
 import pytest
-from src.domain.models.source import Source
+from src.domain.models.source import Source, SourceRequest
 from src.domain.ports.sources_port import SourcePort
 from src.domain.services.source_service import SourceService
 
@@ -57,3 +57,49 @@ def test_get_all_sources_that_returns_empty(source_service, mock_source_port):
     # THEN
     assert result == fake_sources
     mock_source_port.get_all_sources.assert_called_once()
+
+
+def test_update_source_successfully(source_service, mock_source_port):
+    # GIVEN
+    source_external_id = uuid4()
+    source_id = 123
+    existing_source = Source(
+        id=source_id,
+        external_id=source_external_id,
+        url="https://old.url.com",
+        name="Old Name",
+        created_at=datetime(2025, 1, 1, 12, 0, 0),
+    )
+    update_request = SourceRequest(url="https://new.url.com", name="New Name")
+    updated_source = Source(
+        id=source_id,
+        external_id=source_external_id,
+        url=update_request.url,
+        name=update_request.name,
+        created_at=existing_source.created_at,
+    )
+    mock_source_port.get_source_by_external_id.return_value = existing_source
+    mock_source_port.update_source.return_value = updated_source
+
+    # WHEN
+    result = source_service.update_source(source_external_id, update_request)
+
+    # THEN
+    assert result == updated_source
+    mock_source_port.get_source_by_external_id.assert_called_once_with(source_external_id)
+    mock_source_port.update_source.assert_called_once_with(source_id, update_request)
+
+
+def test_update_source_returns_none_when_source_not_found(source_service, mock_source_port):
+    # GIVEN
+    non_existent_external_id = uuid4()
+    update_request = SourceRequest(url="https://any.url.com", name="Any Name")
+    mock_source_port.get_source_by_external_id.return_value = None
+
+    # WHEN
+    result = source_service.update_source(non_existent_external_id, update_request)
+
+    # THEN
+    assert result is None
+    mock_source_port.get_source_by_external_id.assert_called_once_with(non_existent_external_id)
+    mock_source_port.update_source.assert_not_called()


### PR DESCRIPTION
# Description
This Pull Request adds 3 new endpoints for sources:
- `GET /v1/sources/{external_id}`
- `PUT /v1/sources/{external_id}`
- `DELETE /v1/sources/{external_id}`

<img width="1429" height="813" alt="image" src="https://github.com/user-attachments/assets/f8262bf0-ba2e-4ad6-9a3a-953b2452c896" />
<img width="1432" height="1011" alt="image" src="https://github.com/user-attachments/assets/a4e11071-1b9f-43e6-a839-7eee75a1459b" />
<img width="1432" height="896" alt="image" src="https://github.com/user-attachments/assets/c2fbf03d-15d1-40d1-89cd-f73ac6908be6" />

